### PR TITLE
Add support for 'headless mode'

### DIFF
--- a/artificial_life.py
+++ b/artificial_life.py
@@ -13,8 +13,6 @@ import datetime
 
 from screen_output import ScreenController
 
-from pynput.keyboard import KeyCode, Listener
-
 from collections import deque
 
 from pixel_composer.rasterizer import ScreenDrawer, FrameBuffer, FullScreenPatternShader, PerPixelLightingShader, \
@@ -1197,6 +1195,7 @@ def on_press(key):
     :param key:
     :return:
     """
+    from pynput.keyboard import KeyCode
     if key == KeyCode(char='T'):
         thanos_snap()
     if key == KeyCode(char='G'):
@@ -1585,6 +1584,10 @@ if __name__ == '__main__':
                         help='Whether to bypass pixel composer and use fixed function '
                              'for drawing (faster, less pretty)')
 
+    parser.add_argument('-hl', '--headless', action="store_true", dest="headless",
+                        default=headless,
+                        help='Whether to run in headless mode (without a keyboard listener)')
+
     args = parser.parse_args()
 
     logging.basicConfig(level=args.log_level)
@@ -1618,8 +1621,10 @@ if __name__ == '__main__':
 
     current_session.rendering_on = True
 
-    listener = Listener(on_press=on_press, daemon=True)
-    listener.start()
+    if not args.headless:
+        from pynput.keyboard import Listener
+        listener = Listener(on_press=on_press, daemon=True)
+        listener.start()
 
     Thread(target=main, daemon=True).start()
 

--- a/config/parameters.py
+++ b/config/parameters.py
@@ -24,3 +24,4 @@ walls = 0
 resources = 0
 entities_build_walls = True
 wall_chance_multiplier = 512
+headless = False


### PR DESCRIPTION
This disables the pynput imports and the keyboard listener for headless Pi installs where X is not installed and/or a keyboard is not available